### PR TITLE
Update lzma-uncramfs.c

### DIFF
--- a/lzma-uncramfs.c
+++ b/lzma-uncramfs.c
@@ -12,6 +12,7 @@
 //#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <sys/sysmacros.h>
 
 // Unix things
 #include <unistd.h>


### PR DESCRIPTION
On newer systems an error prevents the build. This fixes it. Tested on Ubuntu 21.04 and 20.04 with gcc 8,9 and 10  